### PR TITLE
Add sticky mode to keep a post at the top

### DIFF
--- a/news/migrations/0003_auto__add_field_newsitem_sticky.py
+++ b/news/migrations/0003_auto__add_field_newsitem_sticky.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'NewsItem.sticky'
+        db.add_column(u'news_newsitem', 'sticky',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'NewsItem.sticky'
+        db.delete_column(u'news_newsitem', 'sticky')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'core.collabuser': {
+            'Meta': {'object_name': 'CollabUser'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '254', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '75', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '75', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '75'})
+        },
+        u'news.feedsubscription': {
+            'Meta': {'object_name': 'FeedSubscription'},
+            'feed': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['news.NewsFeed']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.CollabUser']"})
+        },
+        u'news.newsfeed': {
+            'Meta': {'object_name': 'NewsFeed'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'news.newsitem': {
+            'Meta': {'object_name': 'NewsItem'},
+            'body': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'create_user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.CollabUser']"}),
+            'feed': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['news.NewsFeed']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'publish_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sticky': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['news']

--- a/news/models.py
+++ b/news/models.py
@@ -24,6 +24,7 @@ class NewsItem(models.Model):
     publish_date = models.DateTimeField()
     published = models.BooleanField(default=False)
     create_user = models.ForeignKey(AUTH_USER_MODEL)
+    sticky = models.BooleanField(default=False)
     feed = models.ForeignKey('NewsFeed')
 
     def __unicode__(self):

--- a/news/templates/news/home_widget.html
+++ b/news/templates/news/home_widget.html
@@ -5,7 +5,20 @@
     <h1>Announcements</h1>
     {% cache 180 core_news %}
 
-        <ul>
+        <ul class='sticky_news_items'>
+            {% for item in sticky_news %}
+          <li>
+            <ul class="span10">
+              <li>
+                    <a href="{% url "news:item" item.slug %}">{{ item.title }}</a>
+                <p>{% autoescape off %}{{ item.body|striptags|truncatewords:"20" }}{% endautoescape %}</p>
+              </li>
+            </ul>
+          </li>
+            {% endfor %}
+        </ul>
+
+        <ul class='news_items'>
             {% for item in recent_news %}
           <li>
             <span class="date span1">

--- a/news/templates/news/news.html
+++ b/news/templates/news/news.html
@@ -20,8 +20,20 @@
     <div class="row">
         <div class="span9">
             <div class="row">
-                <div class="feed_block">
-                    <ul>
+                <div class="feed_block feed_news">
+                    <ul class="sticky_news_items">
+                    {% for a in sticky_items %}
+                        <li>
+                            <ul class="span10">
+                              <li>
+                                <a href="{% url "news:item" a.slug %}">{{ a.title }}</a>
+                                <p>{{ a.body|striptags|truncatewords:25 }}</p>
+                              </li>
+                            </ul>
+                        </li>
+                    {% endfor %}
+                    </ul>
+                    <ul class="news_items">
                     {% for a in items %}
                         <li>
                             <span class="date span1">
@@ -36,6 +48,7 @@
                             </ul>
                         </li>
                     {% endfor %}
+                    </ul>
                 </div>
             </div>
         </div>

--- a/news/views.py
+++ b/news/views.py
@@ -33,12 +33,14 @@ def news_item(req, slug):
 @cache_page(60 * 5)
 def news_list(req, slug=None):
     p = _create_params(req)
-    p['items'] = NewsItem.objects.filter(published=True). \
+    news = NewsItem.objects.filter(published=True). \
         order_by('-publish_date')
     if slug:
         feed = get_object_or_404(NewsFeed, slug=slug)
         p['selected_feed'] = feed
-        p['items'] = p['items'].filter(feed_id=feed.id)
+        news = news.filter(feed_id=feed.id)
+    p['sticky_items'] = news.filter(sticky=True)
+    p['items'] = news.filter(sticky=False)
     p['news_feeds'] = NewsFeed.objects.order_by('title')
     return render_to_response(TEMPLATE_PATH + "news.html", p,
                               context_instance=RequestContext(req))

--- a/news/widgets.py
+++ b/news/widgets.py
@@ -8,8 +8,16 @@ class NewsWidget(Widget):
     priority = 1
 
     def get_context(self, context, user):
+        news = NewsItem.objects.filter(published=True).order_by('-publish_date')
+        sticky_news = news.filter(sticky=True)[:3]
+        if len(sticky_news) >= 3:
+            recent_news = news.none()
+        else:
+            recent_news = news.filter(sticky=False)[:3-len(sticky_news)]
+
         return {
-            'recent_news': NewsItem.objects.filter(published=True).order_by('-publish_date')[:3]
+            'recent_news': recent_news,
+            'sticky_news': sticky_news
         }
 
 registry.register('news', NewsWidget())


### PR DESCRIPTION
Why: In the event that a news topic is high profile and should remain visible over time, despite other news items getting posted after it.

What:
Sticky mode can be enabled for any news item to force it's presence at the top of the news list.

Sticky news items look the same as regular news items, except the date is removed and there's a different background color

For the widget (i.e. on the Collab home page), all sticky news items are display regardless of count.  Regular news items will be loaded below only if there are less than 3 sticky news items.

For the news pages, all news items are displayed regardless of count, and all sticky news items are at the top.