### PR TITLE
First/last wasn't working if only one item

### DIFF
--- a/news/templates/news/home_widget.html
+++ b/news/templates/news/home_widget.html
@@ -9,7 +9,7 @@
             {% for item in sticky_news %}
           <li>
             <ul class="span10">
-              <li class='{% if forloop.first %}first{% endif %}{% if forloop.last %}last{% endif %}'>
+              <li class='{% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %}'>
                     <a href="{% url "news:item" item.slug %}">{{ item.title }}</a>
                 <p>{% autoescape off %}{{ item.body|striptags|truncatewords:"20" }}{% endautoescape %}</p>
               </li>
@@ -29,7 +29,7 @@
             </span>
 
             <ul class="span10">
-              <li class='{% if forloop.first %}first{% endif %}{% if forloop.last %}last{% endif %}'>
+              <li class='{% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %}'>
                     <a href="{% url "news:item" item.slug %}">{{ item.title }}</a>
                 <p>{% autoescape off %}{{ item.body|striptags|truncatewords:"20" }}{% endautoescape %}</p>
               </li>

--- a/news/templates/news/news.html
+++ b/news/templates/news/news.html
@@ -25,7 +25,7 @@
                     {% for a in sticky_items %}
                         <li>
                             <ul class="span10">
-                              <li class='{% if forloop.first %}first{% endif %}{% if forloop.last %}last{% endif %}'>
+                              <li class='{% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %}'>
                                 <a href="{% url "news:item" a.slug %}">{{ a.title }}</a>
                                 <p>{{ a.body|striptags|truncatewords:25 }}</p>
                               </li>
@@ -41,7 +41,7 @@
                             </span>
 
                             <ul class="span10">
-                              <li class='{% if forloop.first %}first{% endif %}{% if forloop.last %}last{% endif %}'>
+                              <li class='{% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %}'>
                                 <a href="{% url "news:item" a.slug %}">{{ a.title }}</a>
                                 <p>{{ a.body|striptags|truncatewords:25 }}</p>
                               </li>


### PR DESCRIPTION
If there is only one sticky item, the result was `class='firstlast'`