### PR TITLE
Change number of news items in home widget to 6 

### DIFF
--- a/news/tests.py
+++ b/news/tests.py
@@ -63,24 +63,24 @@ class NewsWidgetViewTest(TestCase):
 
     def test_no_stickies(self):
         response = self.widget.get_context(None, None)
-        self.assertEquals(len(response['recent_news']), 4)
+        self.assertEquals(len(response['recent_news']), 6)
         self.assertEquals(len(response['sticky_news']), 0)
 
     def test_one_sticky(self):
         create_news_items(is_sticky=True, amount=1)
         response = self.widget.get_context(None, None)
-        self.assertEquals(len(response['recent_news']), 3)
+        self.assertEquals(len(response['recent_news']), 5)
         self.assertEquals(len(response['sticky_news']), 1)
 
-    def test_four_stickies(self):
-        create_news_items(is_sticky=True, amount=4)
+    def test_six_stickies(self):
+        create_news_items(is_sticky=True, amount=6)
         response = self.widget.get_context(None, None)
         self.assertEquals(len(response['recent_news']), 0)
-        self.assertEquals(len(response['sticky_news']), 4)
+        self.assertEquals(len(response['sticky_news']), 6)
 
-    def test_five_stickies(self):
-        create_news_items(is_sticky=True, amount=5)
+    def test_seven_stickies(self):
+        create_news_items(is_sticky=True, amount=7)
         response = self.widget.get_context(None, None)
         self.assertEquals(len(response['recent_news']), 0)
-        self.assertEquals(len(response['sticky_news']), 4)
+        self.assertEquals(len(response['sticky_news']), 6)
 

--- a/news/tests.py
+++ b/news/tests.py
@@ -54,9 +54,8 @@ class NewsItemsTest(WebTest):
 
 
 class NewsWidgetViewTest(TestCase):
-    fixtures = ['core-test-fixtures', 'news_fixtures.json']
-
     def setUp(self):
+        create_news_items(is_sticky=False, amount=7)
         feed = NewsFeed(title='second feed')
         feed.save()
         self.widget = NewsWidget()

--- a/news/widgets.py
+++ b/news/widgets.py
@@ -9,11 +9,11 @@ class NewsWidget(Widget):
 
     def get_context(self, context, user):
         news = NewsItem.objects.filter(published=True).order_by('-publish_date')
-        sticky_news = news.filter(sticky=True)[:4]
-        if len(sticky_news) >= 4:
+        sticky_news = news.filter(sticky=True)[:6]
+        if len(sticky_news) >= 6:
             recent_news = news.none()
         else:
-            recent_news = news.filter(sticky=False)[:4-len(sticky_news)]
+            recent_news = news.filter(sticky=False)[:6-len(sticky_news)]
 
         return {
             'recent_news': recent_news,


### PR DESCRIPTION
In conjunction with removing the press clip headlines from the homepage, we want to use the space to display more news items.