### PR TITLE
Show create_user field options as "Lastname, Firstname" and filter out inactive users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#News
+# News
 
 [![Build Status](https://travis-ci.org/cfpb/collab-news.svg?branch=master)](https://travis-ci.org/cfpb/collab-news)
 
@@ -6,7 +6,7 @@
 The articles can be categorized in feeds or rendered on the main page.
 
 
-##Pages
+## Pages
 
 News has different views:
 
@@ -14,11 +14,13 @@ News has different views:
 * Feed page (only that feed's articles)
 * Article detail
 
-##Screenshot
+
+## Screenshot
 
 ![index page](screenshots/main.png "Index Page")
 
-##Installation
+
+## Installation
 
 To use this application you will need to first have [Collab](https://github.com/cfpb/collab) installed.
 
@@ -39,6 +41,7 @@ Once the application is installed, add it to core collab's `INSTALLED_APPS` in y
 INSTALLED_APPS += ( 'news', )
 ```
 
-##Contributing
+
+## Contributing
 
 Please read the [contributing guide](./CONTRIBUTING.md).

--- a/news/admin.py
+++ b/news/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
-from news.models import FeedSubscription, NewsItem, NewsFeed
+from news.models import FeedSubscription, NewsFeed, NewsItem, NewsItemAdmin
 
 admin.site.register(FeedSubscription)
 admin.site.register(NewsFeed)
-admin.site.register(NewsItem)
+admin.site.register(NewsItem, NewsItemAdmin)

--- a/news/models.py
+++ b/news/models.py
@@ -1,6 +1,10 @@
+from django import forms
+from django.contrib import admin
+from django.contrib.auth import get_user_model
 from django.db import models
-from collab.settings import AUTH_USER_MODEL
 from django.template.defaultfilters import slugify
+
+from collab.settings import AUTH_USER_MODEL
 
 
 class NewsFeed(models.Model):
@@ -57,6 +61,26 @@ class NewsItem(models.Model):
     @property
     def to_search_result(self):
         return self.title
+
+
+class CustomModelChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        return "%s, %s" % (obj.last_name, obj.first_name)
+
+
+class NewsItemAdminForm(forms.ModelForm):
+    create_user = CustomModelChoiceField(
+        queryset=get_user_model().objects.filter(is_active=True).order_by(
+            'last_name', 'first_name'
+        ).all()
+    )
+
+    class Meta:
+        model = NewsItem
+
+
+class NewsItemAdmin(admin.ModelAdmin):
+    form = NewsItemAdminForm
 
 
 class FeedSubscription(models.Model):


### PR DESCRIPTION
They were previously displaying as the user's email address, which is not as helpful, and showing all users for all time, not just active users (i.e., current employees, in our organization).

## Before:

![](https://user-images.githubusercontent.com/1044670/81957474-9ac17400-95da-11ea-899a-fe4591ff7f66.png)

(The problem is much more worse and obvious with production data, but there you go.)

## After:

![](https://user-images.githubusercontent.com/1044670/81956009-cd6a6d00-95d8-11ea-8785-ab86e2c08ea0.png)

## Review

Can't add you as a reviewer, @higs4281.
