### PR TITLE
Also exclude users with no name from create_user widget

### DIFF
--- a/news/models.py
+++ b/news/models.py
@@ -70,8 +70,10 @@ class CustomModelChoiceField(forms.ModelChoiceField):
 
 class NewsItemAdminForm(forms.ModelForm):
     create_user = CustomModelChoiceField(
-        queryset=get_user_model().objects.filter(is_active=True).order_by(
-            'last_name', 'first_name'
+        queryset=get_user_model().objects.filter(is_active=True).exclude(
+            first_name='',
+            last_name='',
+        ).order_by('last_name', 'first_name')
         ).all()
     )
 

--- a/news/models.py
+++ b/news/models.py
@@ -70,11 +70,9 @@ class CustomModelChoiceField(forms.ModelChoiceField):
 
 class NewsItemAdminForm(forms.ModelForm):
     create_user = CustomModelChoiceField(
-        queryset=get_user_model().objects.filter(is_active=True).exclude(
-            first_name='',
-            last_name='',
-        ).order_by('last_name', 'first_name')
-        ).all()
+        queryset=get_user_model().objects.order_by(
+            'last_name', 'first_name'
+        ).filter(is_active=True).exclude(first_name='', last_name='')
     )
 
     class Meta:


### PR DESCRIPTION
Our production data includes a lot of users with no names, which clutter the top of the list. Let's not show those, either.

@higs4281